### PR TITLE
Missing space in hover text

### DIFF
--- a/indicator.html
+++ b/indicator.html
@@ -17,7 +17,7 @@
 
       // change icon tooltip
       chrome.pageAction.setTitle({
-          title: tab.url + (res.spdy ? ' is SPDY-enabled' : 'is NOT SPDY-enabled')
+          title: tab.url + (res.spdy ? ' is SPDY-enabled' : ' is NOT SPDY-enabled')
         , tabId: tab.id
       });
     } else {


### PR DESCRIPTION
The hover text for no spdy is missing a leading space, literally a one character fix. This is just so you don't have to find it if you don't want to.
