### PR TITLE
show icon in chrome://chrome/extensions/

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -13,4 +13,7 @@
         "default_title": "SPDY"
     }
   , "options_page": "options.html"
+  , "icons": {
+        "128": "icon.png"
+    }
 }


### PR DESCRIPTION
By adding the "icons" property to the manifest, you can show the extension's icon in the settings page.
