### PR TITLE
Fix chrome://net-internals/#spdy -> chrome://net-internals/#http2

### DIFF
--- a/indicator.js
+++ b/indicator.js
@@ -2,7 +2,7 @@ function onPageActionClicked (tab) {
   chrome.pageAction.getTitle({tabId: tab.id}, function(result) {
     chrome.tabs.create({
       index: tab.index + 1,
-      url: 'chrome://net-internals/#' + (result.match(/QUIC/) ? 'quic' : 'spdy'),
+      url: 'chrome://net-internals/#' + (result.match(/QUIC/) ? 'quic' : 'http2'),
       openerTabId: tab.id
     });
   });


### PR DESCRIPTION
For now `chrome://net-internals/#http2` page contains all about h2/spdy and some about quic. General info about quic still stays on `chrome://net-internals/#quic`.

Chrome Stable 45.0.2454.101 m.