### PR TITLE
Add default icon to prevent flashing of extension icon

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -17,6 +17,9 @@
     }]
   , "page_action": {
         "default_title": "HTTP/2 and SPDY"
+      , "default_icon": {
+        "19": "icon-no-spdy.png"
+      }
     }
   , "options_page": "options.html"
   , "web_accessible_resources": [


### PR DESCRIPTION
Fixes rauchg/chrome-spdy-indicator#27

Uses the default icon (that will appear paler than usual until the extension sets the actual one)

Does not solve the stretched icon - that requires a separate fix.