### PR TITLE
Make content script message background without prompting

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,8 +1,6 @@
-chrome.runtime.onMessage.addListener(function (res, sender, sendResponse) {
-  var loadTimes = window.chrome.loadTimes();
-  // send spdy info for current page
-  chrome.runtime.sendMessage({
-    spdy: loadTimes.wasFetchedViaSpdy,
-    info: loadTimes.npnNegotiatedProtocol || loadTimes.connectionInfo
-  });
+var loadTimes = window.chrome.loadTimes();
+// send spdy info for current page
+chrome.runtime.sendMessage({
+  spdy: loadTimes.wasFetchedViaSpdy,
+  info: loadTimes.npnNegotiatedProtocol || loadTimes.connectionInfo
 });

--- a/indicator.js
+++ b/indicator.js
@@ -67,5 +67,5 @@ chrome.runtime.onMessage.addListener(function (res, sender) {
 // For preloaded pages, the message might've been sent already
 // This forces a new message in case this happened
 chrome.tabs.onReplaced.addListener(function(addedTabId, removedTabId) {
-  chrome.tabs.executeScript({file: "content.js"});
+  chrome.tabs.executeScript(addedTabId, {file: "content.js"});
 });

--- a/indicator.js
+++ b/indicator.js
@@ -63,3 +63,9 @@ chrome.runtime.onMessage.addListener(function (res, sender) {
     chrome.pageAction.hide(tab.id);
   }
 });
+
+// For preloaded pages, the message might've been sent already
+// This forces a new message in case this happened
+chrome.tabs.onReplaced.addListener(function(addedTabId, removedTabId) {
+  chrome.tabs.executeScript({file: "content.js"});
+});

--- a/indicator.js
+++ b/indicator.js
@@ -63,9 +63,3 @@ chrome.runtime.onMessage.addListener(function (res, sender) {
     chrome.pageAction.hide(tab.id);
   }
 });
-
-chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
-  if(changeInfo.status == "complete") {
-    chrome.tabs.sendMessage(tabId, {});
-  }
-});


### PR DESCRIPTION
At `"document_start"`, the content script already has the data, there is no need to wait until the tab completes loading.

Therefore, this pull request reverses the messaging logic: instead of setting up a listener for a message in the content script and requesting data when `tabs.onUpdated` triggers with `"complete"` state, the content script sends the message immediately.

From the user perspective, this results in the indicator appearing in the correct state as soon as the page starts loading instead of after it (fully!) loads. This can be seconds of difference.

Performance impact on page loading is ~2ms (~6ms instead of ~4ms for setting up the listener).