### PR TITLE
Switch to Event page model for background

### DIFF
--- a/indicator.js
+++ b/indicator.js
@@ -54,11 +54,6 @@ chrome.runtime.onMessage.addListener(function (res, sender) {
         title: tooltip + '-enabled' + (res.spdy ? '(' + res.info + ')' : '')
       , tabId: tab.id
     });
-
-    // set click destination
-    if (!chrome.pageAction.onClicked.hasListener(onPageActionClicked)) {
-      chrome.pageAction.onClicked.addListener(onPageActionClicked);
-    }
   } else {
     chrome.pageAction.hide(tab.id);
   }
@@ -69,3 +64,5 @@ chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
     chrome.tabs.sendMessage(tabId, {});
   }
 });
+
+chrome.pageAction.onClicked.addListener(onPageActionClicked);

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   , "manifest_version": 2
   , "permissions": ["tabs"]
   , "background": {
-        "persistent": true
+        "persistent": false
       , "scripts": [
           "indicator.js"
         ]


### PR DESCRIPTION
The background page is stateless and does not use any problematic APIs.

Therefore, one can safely switch to [Event page model](https://developer.chrome.com/extensions/event_pages) to free (a bit) of resources in case there are few-and-far-between navigations.