### PR TITLE
Speed up indication & fix preloaded pages

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,8 +1,6 @@
-chrome.runtime.onMessage.addListener(function (res, sender, sendResponse) {
-  var loadTimes = window.chrome.loadTimes();
-  // send spdy info for current page
-  chrome.runtime.sendMessage({
-    spdy: loadTimes.wasFetchedViaSpdy,
-    info: loadTimes.npnNegotiatedProtocol || loadTimes.connectionInfo
-  });
+var loadTimes = window.chrome.loadTimes();
+// send spdy info for current page
+chrome.runtime.sendMessage({
+  spdy: loadTimes.wasFetchedViaSpdy,
+  info: loadTimes.npnNegotiatedProtocol || loadTimes.connectionInfo
 });

--- a/content.js
+++ b/content.js
@@ -4,3 +4,10 @@ chrome.runtime.sendMessage({
   spdy: loadTimes.wasFetchedViaSpdy,
   info: loadTimes.npnNegotiatedProtocol || loadTimes.connectionInfo
 });
+
+chrome.runtime.onMessage.addListener(function (res, sender, sendResponse) {
+  chrome.runtime.sendMessage({
+    spdy: loadTimes.wasFetchedViaSpdy,
+    info: loadTimes.npnNegotiatedProtocol || loadTimes.connectionInfo
+  });
+});

--- a/indicator.js
+++ b/indicator.js
@@ -63,3 +63,9 @@ chrome.runtime.onMessage.addListener(function (res, sender) {
     chrome.pageAction.hide(tab.id);
   }
 });
+
+// For preloaded pages, the message might've been sent already
+// This forces a new message in case this happened
+chrome.tabs.onReplaced.addListener(function(addedTabId, removedTabId) {
+  chrome.tabs.sendMessage(addedTabId, {});
+});

--- a/indicator.js
+++ b/indicator.js
@@ -63,9 +63,3 @@ chrome.runtime.onMessage.addListener(function (res, sender) {
     chrome.pageAction.hide(tab.id);
   }
 });
-
-chrome.tabs.onUpdated.addListener(function(tabId, changeInfo, tab) {
-  if(changeInfo.status == "complete") {
-    chrome.tabs.sendMessage(tabId, {});
-  }
-});


### PR DESCRIPTION
This PR combines 2 features:

1) Instead of waiting for the page to load, the content script immediately messages the background. At `document_start`, the required information is already available and can be used immediately. From the user perspective, this allows the indicator to appear when the page starts loading, not when it finishes loading. The performance impact on page loading seems to be negligible (within ~2ms).

2) As per #32, after a page swap page actions need to be shown again - this provides a workaround, by querying the content script again after a page is swapped in.