### PR TITLE
replace deprecated chrome.loadTimes

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,13 +1,34 @@
-var loadTimes = window.chrome.loadTimes();
-// send spdy info for current page
+function connectionInfo() {
+  if (window.PerformanceNavigationTiming) {
+    const ntEntry = performance.getEntriesByType('navigation')[0];
+    return ntEntry.nextHopProtocol;
+  }
+}
+function wasFetchedViaSpdy() {
+  // SPDY is deprecated in favor of HTTP/2, but this implementation returns
+  // true for HTTP/2 or HTTP2+QUIC/39 as well.
+  if (window.PerformanceNavigationTiming) {
+    const ntEntry = performance.getEntriesByType('navigation')[0];
+    return ['h2', 'hq'].includes(ntEntry.nextHopProtocol);
+  }
+}
+function npnNegotiatedProtocol() {
+  // NPN is deprecated in favor of ALPN, but this implementation returns the
+  // HTTP/2 or HTTP2+QUIC/39 requests negotiated via ALPN.
+  if (window.PerformanceNavigationTiming) {
+    const ntEntry = performance.getEntriesByType('navigation')[0];
+    return ['h2', 'hq'].includes(ntEntry.nextHopProtocol) ?
+        ntEntry.nextHopProtocol : 'unknown';
+  }
+}
 chrome.runtime.sendMessage({
-  spdy: loadTimes.wasFetchedViaSpdy,
-  info: loadTimes.npnNegotiatedProtocol || loadTimes.connectionInfo
+  spdy: wasFetchedViaSpdy(),
+  info: npnNegotiatedProtocol() || connectionInfo()
 });
 
 chrome.runtime.onMessage.addListener(function (res, sender, sendResponse) {
   chrome.runtime.sendMessage({
-    spdy: loadTimes.wasFetchedViaSpdy,
-    info: loadTimes.npnNegotiatedProtocol || loadTimes.connectionInfo
+    spdy: wasFetchedViaSpdy(),
+    info: npnNegotiatedProtocol() || connectionInfo()
   });
 });


### PR DESCRIPTION
[Deprecation] chrome.loadTimes() is deprecated, instead use standardized API: nextHopProtocol in Navigation Timing 2. https://www.chromestatus.com/features/5637885046816768.
- tested on chrome 71