### PR TITLE
Remove unused 'tabs' permission

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "HTTP/2 and SPDY indicator"
   , "description": "An indicator button for HTTP/2, SPDY and QUIC support by each website."
-  , "version": "1.0.0"
+  , "version": "1.0.1"
   , "manifest_version": 2
   , "background": {
         "persistent": false

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,6 @@
   , "description": "An indicator button for HTTP/2, SPDY and QUIC support by each website."
   , "version": "1.0.0"
   , "manifest_version": 2
-  , "permissions": ["tabs"]
   , "background": {
         "persistent": false
       , "scripts": [


### PR DESCRIPTION
The "tabs" permission isn't necessary as it only grants access to a couple of properties on Tab instances. This permission is not necessary for general interaction with the Tabs API. 